### PR TITLE
Missing config.Env wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import (
 )
 
 stytchAPIClient := stytchapi.NewAPIClient(
-	stytch.EnvTest, // available environments are EnvTest and EnvLive
+	config.Env(stytch.EnvTest), // available environments are EnvTest and EnvLive
 	"project-live-c60c0abe-c25a-4472-a9ed-320c6667d317",
 	"secret-live-80JASucyk7z_G8Z-7dVwZVGXL5NT_qGAQ2I=",
 )


### PR DESCRIPTION
In the readme example, stytch.EnvTest needs to be wrapped in config.Env, as specified in other sections of the code.